### PR TITLE
feat: 巡礼進捗管理 - 参拝済み寺院の記録・管理 #3

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { temples } from '@/data/temples';
 import { Temple } from '@/types/temple';
+import { useVisitedTemples } from '@/contexts/visited-temples-context';
 
 const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY!;
 
@@ -21,6 +22,7 @@ const INITIAL_REGION: Region = {
 export default function MapScreen() {
   const mapRef = useRef<MapView>(null);
   const [origin, setOrigin] = useState<LatLng | null>(null);
+  const { isVisited } = useVisitedTemples();
   const [destination, setDestination] = useState<Temple | null>(null);
   const [mode, setMode] = useState<'WALKING' | 'DRIVING'>('WALKING');
   const locationSubscription = useRef<Location.LocationSubscription | null>(null);
@@ -72,7 +74,7 @@ export default function MapScreen() {
             title={`第${temple.id}番`}
             tracksViewChanges={false}
           >
-            <View style={styles.pin}>
+            <View style={[styles.pin, isVisited(temple.id) && styles.pinVisited]}>
               <Text style={styles.pinText}>{temple.id}</Text>
             </View>
             <Callout>
@@ -157,6 +159,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.3,
     shadowRadius: 2,
     elevation: 3,
+  },
+  pinVisited: {
+    backgroundColor: '#27ae60',
   },
   pinText: {
     color: '#fff',

--- a/app/(tabs)/temples.tsx
+++ b/app/(tabs)/temples.tsx
@@ -1,5 +1,6 @@
 import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
@@ -11,10 +12,11 @@ const TOTAL = temples.length;
 export default function TempleListScreen() {
   const { count, isVisited } = useVisitedTemples();
   const progress = count / TOTAL;
+  const { top } = useSafeAreaInsets();
 
   return (
     <ThemedView style={styles.container}>
-      <View style={styles.progressCard}>
+      <View style={[styles.progressCard, { marginTop: top + 8 }]}>
         <View style={styles.progressHeader}>
           <ThemedText style={styles.progressLabel}>巡礼進捗</ThemedText>
           <ThemedText style={styles.progressCount}>
@@ -66,7 +68,6 @@ const styles = StyleSheet.create({
   },
   progressCard: {
     marginHorizontal: 16,
-    marginTop: 16,
     marginBottom: 8,
     padding: 14,
     backgroundColor: '#fff5f5',

--- a/app/(tabs)/temples.tsx
+++ b/app/(tabs)/temples.tsx
@@ -4,30 +4,56 @@ import { router } from 'expo-router';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { temples } from '@/data/temples';
+import { useVisitedTemples } from '@/contexts/visited-temples-context';
+
+const TOTAL = temples.length;
 
 export default function TempleListScreen() {
+  const { count, isVisited } = useVisitedTemples();
+  const progress = count / TOTAL;
+
   return (
     <ThemedView style={styles.container}>
+      <View style={styles.progressCard}>
+        <View style={styles.progressHeader}>
+          <ThemedText style={styles.progressLabel}>巡礼進捗</ThemedText>
+          <ThemedText style={styles.progressCount}>
+            <Text style={styles.progressCountHighlight}>{count}</Text> / {TOTAL} 寺院
+          </ThemedText>
+        </View>
+        <View style={styles.progressTrack}>
+          <View style={[styles.progressFill, { width: `${progress * 100}%` as any }]} />
+        </View>
+      </View>
+
       <FlatList
         data={temples}
         keyExtractor={(item) => String(item.id)}
         contentContainerStyle={styles.list}
-        renderItem={({ item }) => (
-          <TouchableOpacity
-            style={styles.item}
-            onPress={() => router.push(`/temples/${item.id}`)}
-            activeOpacity={0.7}
-          >
-            <View style={styles.badge}>
-              <Text style={styles.badgeText}>{item.id}</Text>
-            </View>
-            <View style={styles.info}>
-              <ThemedText style={styles.name}>{item.name}</ThemedText>
-              <ThemedText style={styles.address}>{item.address}</ThemedText>
-            </View>
-            <Text style={styles.chevron}>›</Text>
-          </TouchableOpacity>
-        )}
+        renderItem={({ item }) => {
+          const visited = isVisited(item.id);
+          return (
+            <TouchableOpacity
+              style={styles.item}
+              onPress={() => router.push(`/temples/${item.id}`)}
+              activeOpacity={0.7}
+            >
+              <View style={[styles.badge, visited && styles.badgeVisited]}>
+                <Text style={styles.badgeText}>{item.id}</Text>
+                {visited && <View style={styles.checkOverlay}><Text style={styles.checkMark}>✓</Text></View>}
+              </View>
+              <View style={styles.info}>
+                <ThemedText style={[styles.name, visited && styles.nameVisited]}>{item.name}</ThemedText>
+                <ThemedText style={styles.address}>{item.address}</ThemedText>
+              </View>
+              {visited ? (
+                <Text style={styles.visitedLabel}>参拝済</Text>
+              ) : (
+                <Text style={styles.chevron}>›</Text>
+              )}
+            </TouchableOpacity>
+          );
+        }}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
       />
     </ThemedView>
@@ -37,6 +63,47 @@ export default function TempleListScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  progressCard: {
+    marginHorizontal: 16,
+    marginTop: 16,
+    marginBottom: 8,
+    padding: 14,
+    backgroundColor: '#fff5f5',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#f5c6c6',
+    gap: 10,
+  },
+  progressHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  progressLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#c0392b',
+  },
+  progressCount: {
+    fontSize: 13,
+    opacity: 0.7,
+  },
+  progressCountHighlight: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: '#c0392b',
+  },
+  progressTrack: {
+    height: 6,
+    backgroundColor: '#f0d0d0',
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: '#c0392b',
+    borderRadius: 3,
   },
   list: {
     paddingVertical: 8,
@@ -57,10 +124,30 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     flexShrink: 0,
   },
+  badgeVisited: {
+    backgroundColor: '#27ae60',
+  },
   badgeText: {
     color: '#fff',
     fontSize: 12,
     fontWeight: '700',
+  },
+  checkOverlay: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    backgroundColor: '#1e8449',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkMark: {
+    color: '#fff',
+    fontSize: 8,
+    fontWeight: '900',
+    lineHeight: 10,
   },
   info: {
     flex: 1,
@@ -70,6 +157,9 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '600',
   },
+  nameVisited: {
+    opacity: 0.6,
+  },
   address: {
     fontSize: 12,
     opacity: 0.6,
@@ -77,6 +167,11 @@ const styles = StyleSheet.create({
   chevron: {
     fontSize: 20,
     opacity: 0.3,
+  },
+  visitedLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#27ae60',
   },
   separator: {
     height: StyleSheet.hairlineWidth,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { VisitedTemplesProvider } from '@/contexts/visited-temples-context';
 
 export const unstable_settings = {
   anchor: '(tabs)',
@@ -13,13 +14,15 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false, title: '寺院一覧' }} />
-        <Stack.Screen name="temples/[id]" options={{ headerShown: true }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <VisitedTemplesProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false, title: '寺院一覧' }} />
+          <Stack.Screen name="temples/[id]" options={{ headerShown: true }} />
+          <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </VisitedTemplesProvider>
   );
 }

--- a/app/temples/[id].tsx
+++ b/app/temples/[id].tsx
@@ -6,11 +6,15 @@ import MapView, { Marker } from 'react-native-maps';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { temples } from '@/data/temples';
+import { useVisitedTemples } from '@/contexts/visited-temples-context';
 
 export default function TempleDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const navigation = useNavigation();
   const temple = temples.find((t) => t.id === Number(id));
+  const { toggle, isVisited } = useVisitedTemples();
+
+  const visited = temple ? isVisited(temple.id) : false;
 
   useEffect(() => {
     if (temple) {
@@ -46,19 +50,36 @@ export default function TempleDetailScreen() {
         scrollEnabled={false}
         zoomEnabled={false}
       >
-        <Marker coordinate={{ latitude: temple.lat, longitude: temple.lng }} />
+        <Marker
+          coordinate={{ latitude: temple.lat, longitude: temple.lng }}
+          pinColor={visited ? '#27ae60' : '#c0392b'}
+        />
       </MapView>
 
       <ThemedView style={styles.content}>
         <View style={styles.header}>
           <ThemedText style={styles.number}>第{temple.id}番</ThemedText>
           <ThemedText style={styles.name}>{temple.name}</ThemedText>
+          {visited && (
+            <View style={styles.visitedBadge}>
+              <Text style={styles.visitedBadgeText}>✓ 参拝済み</Text>
+            </View>
+          )}
         </View>
 
         <View style={styles.row}>
           <ThemedText style={styles.label}>住所</ThemedText>
           <ThemedText style={styles.value}>{temple.address}</ThemedText>
         </View>
+
+        <TouchableOpacity
+          style={[styles.visitButton, visited && styles.visitButtonDone]}
+          onPress={() => toggle(temple.id)}
+        >
+          <Text style={[styles.visitButtonText, visited && styles.visitButtonTextDone]}>
+            {visited ? '✓ 参拝済みを取り消す' : '参拝済みにする'}
+          </Text>
+        </TouchableOpacity>
 
         <TouchableOpacity style={styles.navButton} onPress={openMaps}>
           <Text style={styles.navButtonText}>ナビを開く</Text>
@@ -87,6 +108,21 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '700',
   },
+  visitedBadge: {
+    alignSelf: 'flex-start',
+    marginTop: 4,
+    backgroundColor: '#eafaf1',
+    borderRadius: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderWidth: 1,
+    borderColor: '#a9dfbf',
+  },
+  visitedBadgeText: {
+    fontSize: 12,
+    color: '#27ae60',
+    fontWeight: '600',
+  },
   row: {
     flexDirection: 'row',
     gap: 12,
@@ -101,15 +137,36 @@ const styles = StyleSheet.create({
     fontSize: 14,
     flex: 1,
   },
-  navButton: {
+  visitButton: {
     marginTop: 8,
     backgroundColor: '#c0392b',
     borderRadius: 10,
     paddingVertical: 14,
     alignItems: 'center',
   },
-  navButtonText: {
+  visitButtonDone: {
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+    borderColor: '#27ae60',
+  },
+  visitButtonText: {
     color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  visitButtonTextDone: {
+    color: '#27ae60',
+  },
+  navButton: {
+    backgroundColor: 'transparent',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: '#c0392b',
+  },
+  navButtonText: {
+    color: '#c0392b',
     fontSize: 15,
     fontWeight: '600',
   },

--- a/contexts/visited-temples-context.tsx
+++ b/contexts/visited-temples-context.tsx
@@ -1,0 +1,53 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'visited_temples';
+
+type VisitedTemplesContextType = {
+  visitedIds: Set<number>;
+  toggle: (id: number) => void;
+  isVisited: (id: number) => boolean;
+  count: number;
+};
+
+const VisitedTemplesContext = createContext<VisitedTemplesContextType | null>(null);
+
+export function VisitedTemplesProvider({ children }: { children: React.ReactNode }) {
+  const [visitedIds, setVisitedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then((raw) => {
+      if (raw) {
+        const ids: number[] = JSON.parse(raw);
+        setVisitedIds(new Set(ids));
+      }
+    });
+  }, []);
+
+  const toggle = useCallback((id: number) => {
+    setVisitedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      AsyncStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
+      return next;
+    });
+  }, []);
+
+  const isVisited = useCallback((id: number) => visitedIds.has(id), [visitedIds]);
+
+  return (
+    <VisitedTemplesContext.Provider value={{ visitedIds, toggle, isVisited, count: visitedIds.size }}>
+      {children}
+    </VisitedTemplesContext.Provider>
+  );
+}
+
+export function useVisitedTemples() {
+  const ctx = useContext(VisitedTemplesContext);
+  if (!ctx) throw new Error('useVisitedTemples must be used within VisitedTemplesProvider');
+  return ctx;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -2744,6 +2745,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -7824,6 +7837,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8808,6 +8830,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",


### PR DESCRIPTION
## Summary

- `VisitedTemplesContext` を追加し、`AsyncStorage` で参拝済み状態をアプリ再起動後も永続化
- 詳細画面に「参拝済みにする / ✓ 参拝済みを取り消す」トグルボタンと参拝済みバッジを追加
- 一覧画面に進捗バー（X/34 寺院）を表示し、参拝済み寺院のバッジ・ラベルを緑色で表示
- 地図画面で参拝済み寺院のマーカーを緑色、未参拝を赤色で色分け表示

## Test plan

- [x] 詳細画面で「参拝済みにする」ボタンをタップ → バッジと緑ラベルが表示されること
- [x] 再度タップ → 参拝済みが取り消されること
- [x] 一覧画面の進捗バーが参拝済み数に応じて更新されること
- [x] アプリを再起動後も参拝済み状態が保持されること
- [x] 地図画面で参拝済み寺院のマーカーが緑色で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)