### PR TITLE
feat: 地図画面 UI/UX 改善 #11

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -368,8 +368,8 @@ const styles = StyleSheet.create({
   // 現在地ボタン
   locationButton: {
     position: 'absolute',
-    left: 16,
-    bottom: 140,
+    right: 16,
+    bottom: 16,
     width: 52,
     height: 52,
     borderRadius: 26,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -368,11 +368,11 @@ const styles = StyleSheet.create({
   // 現在地ボタン
   locationButton: {
     position: 'absolute',
-    right: 16,
+    left: 16,
     bottom: 140,
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: 52,
+    height: 52,
+    borderRadius: 26,
     backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,10 +17,12 @@ const INITIAL_REGION: Region = {
   longitudeDelta: 0.22,
 };
 
+const TOTAL_TEMPLES = 34;
+
 export default function MapScreen() {
   const mapRef = useRef<MapView>(null);
   const [origin, setOrigin] = useState<LatLng | null>(null);
-  const { isVisited } = useVisitedTemples();
+  const { isVisited, toggle, count } = useVisitedTemples();
   const [destination, setDestination] = useState<Temple | null>(null);
   const [mode, setMode] = useState<'WALKING' | 'DRIVING'>('WALKING');
   const [routeCoords, setRouteCoords] = useState<LatLng[]>([]);
@@ -67,6 +69,14 @@ export default function MapScreen() {
       },
     );
     setDestination(temple);
+    // ナビ開始時に現在地へ自動センタリング
+    const current = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+    mapRef.current?.animateToRegion({
+      latitude: current.coords.latitude,
+      longitude: current.coords.longitude,
+      latitudeDelta: 0.02,
+      longitudeDelta: 0.02,
+    }, 600);
   }
 
   function clearRoute() {
@@ -77,6 +87,20 @@ export default function MapScreen() {
     setRouteCoords([]);
   }
 
+  async function centerOnCurrentLocation() {
+    const { status } = await Location.getForegroundPermissionsAsync();
+    if (status !== 'granted') {
+      await Location.requestForegroundPermissionsAsync();
+    }
+    const current = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+    mapRef.current?.animateToRegion({
+      latitude: current.coords.latitude,
+      longitude: current.coords.longitude,
+      latitudeDelta: 0.02,
+      longitudeDelta: 0.02,
+    }, 600);
+  }
+
   return (
     <View style={styles.container}>
       <MapView
@@ -85,30 +109,50 @@ export default function MapScreen() {
         initialRegion={INITIAL_REGION}
         showsUserLocation
       >
-        {temples.map((temple) => (
-          <Marker
-            key={temple.id}
-            coordinate={{ latitude: temple.lat, longitude: temple.lng }}
-            title={`第${temple.id}番`}
-            tracksViewChanges={false}
-          >
-            <View style={[styles.pin, isVisited(temple.id) && styles.pinVisited]}>
-              <Text style={styles.pinText}>{temple.id}</Text>
-            </View>
-            <Callout>
-              <ThemedView style={styles.callout}>
-                <ThemedText style={styles.calloutNumber}>第{temple.id}番</ThemedText>
-                <ThemedText style={styles.calloutName}>{temple.name}</ThemedText>
-                <ThemedText style={styles.calloutAddress}>{temple.address}</ThemedText>
-                <CalloutSubview onPress={() => startNavigation(temple)}>
-                  <View style={styles.navButton}>
-                    <Text style={styles.navButtonText}>ナビ開始</Text>
+        {temples.map((temple) => {
+          const visited = isVisited(temple.id);
+          return (
+            <Marker
+              key={temple.id}
+              coordinate={{ latitude: temple.lat, longitude: temple.lng }}
+              title={`第${temple.id}番`}
+              tracksViewChanges={false}
+            >
+              <View style={[styles.pin, visited ? styles.pinVisited : styles.pinUnvisited]}>
+                <Text style={styles.pinText}>{temple.id}</Text>
+                {visited && <View style={styles.pinCheck} />}
+              </View>
+              <Callout>
+                <ThemedView style={styles.callout}>
+                  <View style={styles.calloutHeader}>
+                    <ThemedText style={styles.calloutNumber}>第{temple.id}番</ThemedText>
+                    <View style={[styles.visitedBadge, visited ? styles.visitedBadgeOn : styles.visitedBadgeOff]}>
+                      <Text style={[styles.visitedBadgeText, visited ? styles.visitedBadgeTextOn : styles.visitedBadgeTextOff]}>
+                        {visited ? '参拝済み' : '未参拝'}
+                      </Text>
+                    </View>
                   </View>
-                </CalloutSubview>
-              </ThemedView>
-            </Callout>
-          </Marker>
-        ))}
+                  <ThemedText style={styles.calloutName}>{temple.name}</ThemedText>
+                  <ThemedText style={styles.calloutAddress}>{temple.address}</ThemedText>
+                  <View style={styles.calloutActions}>
+                    <CalloutSubview onPress={() => toggle(temple.id)}>
+                      <View style={[styles.toggleButton, visited ? styles.toggleButtonVisited : styles.toggleButtonUnvisited]}>
+                        <Text style={styles.toggleButtonText}>
+                          {visited ? '✓ 参拝済み' : '参拝済みにする'}
+                        </Text>
+                      </View>
+                    </CalloutSubview>
+                    <CalloutSubview onPress={() => startNavigation(temple)}>
+                      <View style={styles.navButton}>
+                        <Text style={styles.navButtonText}>ナビ開始</Text>
+                      </View>
+                    </CalloutSubview>
+                  </View>
+                </ThemedView>
+              </Callout>
+            </Marker>
+          );
+        })}
 
         {routeCoords.length > 0 && (
           <Polyline
@@ -119,8 +163,23 @@ export default function MapScreen() {
         )}
       </MapView>
 
+      {/* 進捗サマリーバッジ */}
+      <View style={styles.progressBadge}>
+        <Text style={styles.progressBadgeText}>
+          {count} / {TOTAL_TEMPLES} 参拝済み
+        </Text>
+      </View>
+
+      {/* 現在地ボタン */}
+      <TouchableOpacity style={styles.locationButton} onPress={centerOnCurrentLocation}>
+        <Text style={styles.locationButtonText}>⊙</Text>
+      </TouchableOpacity>
+
       {destination && (
         <View style={styles.bottomBar}>
+          <Text style={styles.destinationLabel} numberOfLines={1}>
+            ▶ 第{destination.id}番 {destination.name}
+          </Text>
           <View style={styles.modeToggle}>
             <TouchableOpacity
               style={[styles.modeButton, mode === 'WALKING' && styles.modeButtonActive]}
@@ -155,11 +214,11 @@ const styles = StyleSheet.create({
   map: {
     flex: 1,
   },
+  // マーカー
   pin: {
     width: 28,
     height: 28,
     borderRadius: 14,
-    backgroundColor: '#c0392b',
     borderWidth: 2,
     borderColor: '#fff',
     alignItems: 'center',
@@ -170,23 +229,74 @@ const styles = StyleSheet.create({
     shadowRadius: 2,
     elevation: 3,
   },
+  pinUnvisited: {
+    backgroundColor: '#c0392b',
+  },
   pinVisited: {
     backgroundColor: '#27ae60',
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    borderWidth: 2.5,
+    borderColor: '#fff',
+  },
+  pinCheck: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: '#fff',
+    borderWidth: 1.5,
+    borderColor: '#27ae60',
   },
   pinText: {
     color: '#fff',
     fontSize: 11,
     fontWeight: '700',
   },
+  // コールアウト
   callout: {
-    padding: 8,
-    width: 180,
+    padding: 10,
+    width: 200,
     flexDirection: 'column',
-    gap: 2,
+    gap: 3,
+  },
+  calloutHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 2,
   },
   calloutNumber: {
     fontSize: 11,
     opacity: 0.6,
+  },
+  visitedBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  visitedBadgeOn: {
+    backgroundColor: '#eafaf1',
+    borderWidth: 1,
+    borderColor: '#a9dfbf',
+  },
+  visitedBadgeOff: {
+    backgroundColor: '#fff5f5',
+    borderWidth: 1,
+    borderColor: '#f5c6c6',
+  },
+  visitedBadgeText: {
+    fontSize: 10,
+    fontWeight: '600',
+  },
+  visitedBadgeTextOn: {
+    color: '#27ae60',
+  },
+  visitedBadgeTextOff: {
+    color: '#c0392b',
   },
   calloutName: {
     fontSize: 15,
@@ -196,25 +306,108 @@ const styles = StyleSheet.create({
     fontSize: 12,
     opacity: 0.7,
   },
+  calloutActions: {
+    marginTop: 10,
+    flexDirection: 'row',
+    gap: 8,
+  },
+  toggleButton: {
+    flex: 1,
+    borderRadius: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+    borderWidth: 1,
+  },
+  toggleButtonVisited: {
+    backgroundColor: '#eafaf1',
+    borderColor: '#a9dfbf',
+  },
+  toggleButtonUnvisited: {
+    backgroundColor: '#fff5f5',
+    borderColor: '#f5c6c6',
+  },
+  toggleButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#333',
+  },
   navButton: {
-    marginTop: 16,
+    flex: 1,
     backgroundColor: '#c0392b',
     borderRadius: 6,
     paddingVertical: 6,
-    paddingHorizontal: 12,
+    paddingHorizontal: 8,
     alignItems: 'center',
   },
   navButtonText: {
     color: '#fff',
-    fontSize: 13,
+    fontSize: 12,
     fontWeight: '600',
   },
+  // 進捗サマリーバッジ
+  progressBadge: {
+    position: 'absolute',
+    top: 56,
+    alignSelf: 'center',
+    backgroundColor: 'rgba(255,255,255,0.95)',
+    borderRadius: 20,
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  progressBadgeText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#333',
+  },
+  // 現在地ボタン
+  locationButton: {
+    position: 'absolute',
+    right: 16,
+    bottom: 140,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  locationButtonText: {
+    fontSize: 22,
+    color: '#c0392b',
+  },
+  // ボトムバー
   bottomBar: {
     position: 'absolute',
     bottom: 40,
     alignSelf: 'center',
     alignItems: 'center',
     gap: 10,
+  },
+  destinationLabel: {
+    backgroundColor: 'rgba(255,255,255,0.95)',
+    borderRadius: 16,
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#c0392b',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    elevation: 4,
+    maxWidth: 260,
   },
   modeToggle: {
     flexDirection: 'row',


### PR DESCRIPTION
## 概要

Issue #11 の改善項目をすべて実装しました。

## 変更内容

### 参拝済みマーカーの視認性向上
- 参拝済みマーカーをサイズアップ(28px → 34px)し、右上に白丸バッジを追加
- 色に加えて形状・サイズでも未参拝と区別できるように

### 進捗サマリーバッジ
- 地図上部に「X / 34 参拝済み」バッジを常時表示

### コールアウト UX 改善
- コールアウトに「参拝済み / 未参拝」状態バッジを表示
- 「参拝済みにする」/「✓ 参拝済み」トグルボタンを追加し、詳細画面遷移なしで記録可能に

### ナビゲーション中の UX 改善
- ボトムバーに目的地の寺院名（例: `▶ 第1番 四萬部寺`）を表示
- ナビ開始時に現在地へ自動センタリング

### 現在地ボタン
- 地図右下に現在地へ戻るボタン（⊙）を追加

## 変更ファイル

- `app/(tabs)/index.tsx`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>